### PR TITLE
update pulumi to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pulumi/pulumi:v2.4.0
+FROM pulumi/pulumi:v2.6.1
 
 USER root
 # install tool for packaging lambda functions
@@ -10,7 +10,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Pulumi plugins
-RUN pulumi plugin install resource aws 2.8.0
-RUN pulumi plugin install resource azure 3.8.0
+RUN pulumi plugin install resource aws 2.13.0
+RUN pulumi plugin install resource azure 3.12.1
 
 RUN pulumi plugin ls


### PR DESCRIPTION
Update to pulumi 2.6.1
Includes plugins for:
* AWS 2.13.0
* Azure 3.12.1